### PR TITLE
corrected URL syntax

### DIFF
--- a/news.js
+++ b/news.js
@@ -1,6 +1,6 @@
 const newsApiKey = {
   key: "271c952b09b541eb9c278ed7ed1ecdbb",
-  base: "https://newsapi.org/v2/everything"
+  base: "https://newsapi.org/v2/everything/"
 }
 
 const newsSearchSubmit = document.getElementById("submit-button");
@@ -12,8 +12,8 @@ newsSearchSubmit.addEventListener('click', e => {
   getNewsApiResults(newsSearchString);
 });
 
-const getNewsApiResults = newsSearchString => { // this function will make the request from the news API
-  let url = `${newsApiKey.base}q=${newsSearchString}&apiKey=${newsApiKey.key}`;
+function getNewsApiResults(newsSearchString){ // this function will make the request from the news API
+  let url = `${newsApiKey.base}?q=${newsSearchString}&apiKey=${newsApiKey.key}`;
   axios.get(url).then(res => {
     console.log(res);
   })


### PR DESCRIPTION
I made some minor changes to get the syntax working for the news API call. Just as a note when you look into it before you merge you may notice that we are receiving a 426 error code on the request. this is asking us to upgrade with the client. we either need to limit the amount of data we are importing or look and see if another news api would fit better if this one cannot be limited on each search request.